### PR TITLE
Debounced timeouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/hachiko",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -24,9 +24,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
-      "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
+      "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.0.2",
@@ -41,15 +41,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.3.tgz",
-      "integrity": "sha512-zkOxCS/fA+3SsdA+9Yun0iANxzhQRiNwTvJSr6N95JhuJ/x27z9G2URx1Jpt3zYFfCGUXZGL5UDxt5eyLE7wgw==",
+      "version": "12.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+      "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
       "dev": true
     },
     "arg": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
-      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
+      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
       "dev": true
     },
     "array-from": {
@@ -430,9 +430,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "logform": {
       "version": "2.1.2",
@@ -447,9 +447,9 @@
       }
     },
     "lolex": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.0.1.tgz",
-      "integrity": "sha512-UHuOBZ5jjsKuzbB/gRNNW8Vg8f00Emgskdq2kvZxgBJCS0aqquAuXai/SkWORlKeZEiNQWZjFZOqIUcH9LqKCw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
     },
     "make-error": {
@@ -479,24 +479,16 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "nise": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
-      "integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.1.tgz",
+      "integrity": "sha512-edFWm0fsFG2n318rfEnKlTZTkjlbVOFF9XIA+fj+Ed+Qz1laYW2lobwavWoMzGrYDHH1EpiNJgDfvGnkZztR/g==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/formatio": "^3.2.1",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^2.3.2",
+        "lolex": "^4.1.0",
         "path-to-regexp": "^1.7.0"
-      },
-      "dependencies": {
-        "lolex": {
-          "version": "2.7.5",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
-          "dev": true
-        }
       }
     },
     "object-inspect": {
@@ -564,9 +556,9 @@
       }
     },
     "resolve": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -600,17 +592,17 @@
       }
     },
     "sinon": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
-      "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.4.1.tgz",
+      "integrity": "sha512-7s9buHGHN/jqoy/v4bJgmt0m1XEkCEd/tqdHXumpBp0JSujaT4Ng84JU5wDdK4E85ZMq78NuDe0I3NAqXY8TFg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.4.0",
         "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/samsam": "^3.3.1",
+        "@sinonjs/samsam": "^3.3.2",
         "diff": "^3.5.0",
-        "lolex": "^4.0.1",
-        "nise": "^1.4.10",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.1",
         "supports-color": "^5.5.0"
       }
     },
@@ -621,9 +613,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -678,9 +670,9 @@
       }
     },
     "tape": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.10.2.tgz",
-      "integrity": "sha512-mgl23h7W2yuk3N85FOYrin2OvThTYWdwbk6XQ1pr2PMJieyW2FM/4Bu/+kD/wecb3aZ0Enm+Syinyq467OPq2w==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.11.0.tgz",
+      "integrity": "sha512-yixvDMX7q7JIs/omJSzSZrqulOV51EC9dK8dM0TzImTIkHWfe2/kFyL5v+d9C+SrCMaICk59ujsqFAVidDqDaA==",
       "dev": true,
       "requires": {
         "deep-equal": "~1.0.1",
@@ -689,10 +681,10 @@
         "function-bind": "~1.1.1",
         "glob": "~7.1.4",
         "has": "~1.0.3",
-        "inherits": "~2.0.3",
+        "inherits": "~2.0.4",
         "minimist": "~1.2.0",
         "object-inspect": "~1.6.0",
-        "resolve": "~1.10.1",
+        "resolve": "~1.11.1",
         "resumer": "~0.0.0",
         "string.prototype.trim": "~1.1.2",
         "through": "~2.3.8"
@@ -708,6 +700,12 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
           "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+          "dev": true
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "dev": true
         },
         "minimist": {
@@ -745,9 +743,9 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "ts-node": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.2.0.tgz",
-      "integrity": "sha512-m8XQwUurkbYqXrKqr3WHCW310utRNvV5OnRVeISeea7LoCWVcdfeB/Ntl8JYWFh+WRoUAdBgESrzKochQt7sMw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
+      "integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
@@ -772,9 +770,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "util-deprecate": {
@@ -906,9 +904,9 @@
       }
     },
     "yn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
-      "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/hachiko",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/hachiko",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/hachiko",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A Holochain scenario test Waiter implementation in JS",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/hachiko",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A Holochain scenario test Waiter implementation in JS",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/hachiko",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A Holochain scenario test Waiter implementation in JS",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -18,16 +18,16 @@
   "license": "ISC",
   "dependencies": {
     "colors": "^1.3.3",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "winston": "^3.2.1",
     "winston-null": "^2.0.0"
   },
   "devDependencies": {
-    "@types/node": "^12.0.0",
+    "@types/node": "^12.7.1",
     "faucet": "0.0.1",
-    "sinon": "^7.3.2",
-    "tape": "^4.10.1",
-    "ts-node": "^8.1.0",
-    "typescript": "^3.4.5"
+    "sinon": "^7.4.1",
+    "tape": "^4.11.0",
+    "ts-node": "^8.3.0",
+    "typescript": "^3.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/hachiko",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A Holochain scenario test Waiter implementation in JS",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/hachiko",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A Holochain scenario test Waiter implementation in JS",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/callback.ts
+++ b/src/callback.ts
@@ -1,0 +1,82 @@
+
+import * as colors from 'colors'
+
+import {NodeId} from './elements'
+import {Waiter} from './waiter'
+
+
+export type CallbackData = {
+  // nodes to require consistency for, or all nodes if `null`
+  nodes: Array<NodeId> | null,
+  resolve: () => void,
+  reject?: (any) => void,
+  called?: boolean,
+}
+
+
+export class TimedCallback {
+  // the Waiter that issued this timed callback
+  waiter: any
+
+  // the original CallbackData registered via registerCallback
+  cb: CallbackData
+
+  softInterval: any
+  hardInterval: any
+  id: number
+
+  constructor(waiter: Waiter, cb: CallbackData) {
+    this.cb = cb
+    this.waiter = waiter
+    this.softInterval = null
+    this.hardInterval = null
+  }
+
+  timeoutDump () {
+    console.log("Processed", colors.red('' + this.waiter.completedObservations.length), "signal(s) so far, but")
+    console.log("still waiting on the following", colors.red('' + this.waiter.pendingEffects.length), "signal(s):")
+    console.log(this.waiter.pendingEffects)
+  }
+
+  onSoftTimeout () {
+    console.log(colors.yellow("vvvv    hachiko warning    vvvv"))
+    console.log(
+      colors.yellow("a hachiko callback has been waiting for"),
+      colors.yellow.underline(`${this.waiter.timeoutSettings.softDuration / 1000} seconds`),
+      colors.yellow("with no change"),
+    )
+    this.timeoutDump()
+    console.log(colors.yellow("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"))
+  }
+
+  onHardTimeout () {
+    const observations = this.waiter.completedObservations.map(o => o.observation)
+    console.log(colors.red("vvvv  hachiko timed out!  vvvv"))
+    console.log(
+      colors.red("a hachiko callback has been waiting for"),
+      colors.red.underline(`${this.waiter.timeoutSettings.hardDuration / 1000} seconds`),
+      colors.red("with no change"),
+    )
+    this.timeoutDump()
+    console.log(colors.red("------------------------------"))
+    console.log(colors.red(`Successfully handled ${this.waiter.completedObservations.length} observations:`))
+    console.log(JSON.stringify(observations, null, 2))
+    console.log(colors.red("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"))
+    if (this.cb.reject) {
+      this.cb.reject("hachiko timeout")
+    } else {
+      throw new Error("hachiko timeout!!")
+    }
+  }
+
+  setTimers (): void {
+    this.clearTimers()
+    this.softInterval = setTimeout(this.onSoftTimeout.bind(this), this.waiter.timeoutSettings.softDuration)
+    this.hardInterval = setTimeout(this.onHardTimeout.bind(this), this.waiter.timeoutSettings.hardDuration)
+  }
+
+  clearTimers (): void {
+    clearTimeout(this.softInterval)
+    clearTimeout(this.hardInterval)
+  }
+}

--- a/src/callback.ts
+++ b/src/callback.ts
@@ -80,6 +80,10 @@ export class TimedCallback {
       } else {
         throw new Error("hachiko timeout!!")
       }
+    } else {
+      console.log("Since hachiko is not in strict mode, the test will resume now,")
+      console.log("even though hachiko thinks it will fail. Good luck!")
+      this.cb.resolve()
     }
   }
 

--- a/src/callback.ts
+++ b/src/callback.ts
@@ -15,6 +15,9 @@ export type CallbackData = {
 
 
 export class TimedCallback {
+
+  static _lastId: number
+
   // the Waiter that issued this timed callback
   waiter: any
 
@@ -30,16 +33,16 @@ export class TimedCallback {
     this.waiter = waiter
     this.softInterval = null
     this.hardInterval = null
+    this.id = TimedCallback._lastId++
   }
 
-  totalPending (tc: TimedCallback) {
-    const {id, cb: {nodes, resolve}} = tc
+  totalPending () {
+    const {id, cb: {nodes, resolve}} = this
     const grouped = _.groupBy(this.waiter.pendingEffects, e => e.targetNode)
     return nodes
-      ? nodes.reduce((sum, nodeId) => sum + (nodeId in grouped ? grouped[nodeId].length : 0))
+      ? nodes.reduce((sum, nodeId) => sum + (nodeId in grouped ? grouped[nodeId].length : 0), 0)
       : this.waiter.pendingEffects.length
   }
-
 
   timeoutDump () {
     console.log("Processed", colors.red('' + this.waiter.completedObservations.length), "signal(s) so far, but")
@@ -91,7 +94,9 @@ export class TimedCallback {
   }
 
   initTimers (): void {
-    this.softInterval = setTimeout(this.onSoftTimeout.bind(this), this.waiter.timeoutSettings.softDuration)
-    this.hardInterval = setTimeout(this.onHardTimeout.bind(this), this.waiter.timeoutSettings.hardDuration)
+    this.softInterval = setTimeout(() => this.onSoftTimeout(), this.waiter.timeoutSettings.softDuration)
+    this.hardInterval = setTimeout(() => this.onHardTimeout(), this.waiter.timeoutSettings.hardDuration)
   }
 }
+
+TimedCallback._lastId = 1

--- a/src/callback.ts
+++ b/src/callback.ts
@@ -74,10 +74,12 @@ export class TimedCallback {
     console.log(colors.red(`Successfully handled ${this.waiter.completedObservations.length} observations:`))
     console.log(JSON.stringify(observations, null, 2))
     console.log(colors.red("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"))
-    if (this.cb.reject) {
-      this.cb.reject("hachiko timeout")
-    } else {
-      throw new Error("hachiko timeout!!")
+    if (this.waiter.timeoutSettings.strict) {
+      if (this.cb.reject) {
+        this.cb.reject("hachiko timeout")
+      } else {
+        throw new Error("hachiko timeout!!")
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export {Waiter, NetworkMap} from './waiter'
+export {Waiter, WaiterOptions, NetworkMap} from './waiter'
 export * from './network'
 export * from './elements'

--- a/src/waiter.ts
+++ b/src/waiter.ts
@@ -16,8 +16,8 @@ import logger from './logger'
 import {CallbackData, TimedCallback} from './callback'
 
 
-const DEFAULT_SOFT_TIMEOUT_MS = 8000
-const DEFAULT_HARD_TIMEOUT_MS = 90000
+const DEFAULT_SOFT_TIMEOUT_MS = 5000
+const DEFAULT_HARD_TIMEOUT_MS = 12000
 
 type InstrumentedObservation = {
   observation: Observation,

--- a/src/waiter.ts
+++ b/src/waiter.ts
@@ -26,6 +26,18 @@ type InstrumentedObservation = {
   }
 }
 
+type TimeoutSettings = {
+  softDuration: number,
+  hardDuration: number,
+  strict: boolean
+}
+
+type WaiterOptions = {
+  softTimeout?: number,
+  hardTimeout?: number,
+  strict?: boolean
+}
+
 export type NetworkMap = {[name: string]: NetworkModel}
 
 export class Waiter {
@@ -35,11 +47,11 @@ export class Waiter {
   startTime: number
   callbacks: Array<TimedCallback>
   lastCallbackId: number
-  timeoutSettings: {softDuration: number, hardDuration: number}
+  timeoutSettings: TimeoutSettings
 
   completedObservations: Array<InstrumentedObservation>
 
-  constructor(networks: NetworkMap, opts?) {
+  constructor(networks: NetworkMap, opts?: WaiterOptions) {
     opts = opts || {}
     this.assertUniqueness(networks)
     this.pendingEffects = []
@@ -51,6 +63,7 @@ export class Waiter {
     this.timeoutSettings = {
       softDuration: opts.softTimeout || DEFAULT_SOFT_TIMEOUT_MS,
       hardDuration: opts.hardTimeout || DEFAULT_HARD_TIMEOUT_MS,
+      strict: opts.strict || false
     }
   }
 

--- a/src/waiter.ts
+++ b/src/waiter.ts
@@ -32,7 +32,7 @@ type TimeoutSettings = {
   strict: boolean
 }
 
-type WaiterOptions = {
+export type WaiterOptions = {
   softTimeout?: number,
   hardTimeout?: number,
   strict?: boolean

--- a/src/waiter.ts
+++ b/src/waiter.ts
@@ -69,7 +69,7 @@ export class Waiter {
 
   assertUniqueness (networks: NetworkMap) {
     const nodeIds = _.chain(networks).values().map(n => n.nodes).flatten().value()
-    const frequencies = _.countBy(nodeIds)
+    const frequencies = _.countBy(nodeIds) as {[k: string]: number}
     const dupes = Object.entries(frequencies).filter(([k, v]) => v > 1).map(([k, v]) => k)
     if (dupes.length > 0) {
       logger.debug('found dupes: %j', nodeIds)

--- a/src/waiter.ts
+++ b/src/waiter.ts
@@ -70,7 +70,7 @@ export class Waiter {
     if (this.pendingEffects.length > 0) {
       // make it wait
       const timedCallback = new TimedCallback(this, cb)
-      timedCallback.setTimers()
+      timedCallback.initTimers()
       this.callbacks.push(timedCallback)
       return timedCallback
     } else {
@@ -88,6 +88,7 @@ export class Waiter {
     logger.debug('%j', this.pendingEffects)
     logger.debug(colors.yellow('callbacks: ${this.callbacks.length} total'))
     this.checkCompletion()
+    this.updateTimers(o)
   }
 
   consumeObservation (o: Observation) {

--- a/test/common.ts
+++ b/test/common.ts
@@ -17,22 +17,31 @@ test.only = runTest(tape.only)
 export const observation = (node, signal) => ({node, signal, dna: 'testnet'})
 export const signal = (event, pending) => ({event, pending})
 export const pending = (group, event) => ({group, event})
-export const testCallback = (nodes) => ({
-  resolve: sinon.spy(),
-  reject: sinon.spy(),
-  nodes
-})
+export const testCallbackRealTimeout = (waiter, nodes) => {
+  const cb = waiter.registerCallback({
+    resolve: sinon.spy(),
+    reject: sinon.spy(),
+    nodes
+  })
+  return cb
+}
+export const testCallback = (waiter, nodes) => {
+  const cb = testCallbackRealTimeout(waiter, nodes)
+  cb.onSoftTimeout = sinon.spy()
+  cb.onHardTimeout = sinon.spy()
+  return cb
+}
 
 
-export const resolved = (t, cb) => {
-  t.calledOnce(cb.resolve)
-  t.notCalled(cb.reject)
+export const resolved = (t, tc) => {
+  t.calledOnce(tc.cb.resolve)
+  t.notCalled(tc.cb.reject)
 }
-export const rejected = (t, cb) => {
-  t.notCalled(cb.resolve)
-  t.calledOnce(cb.reject)
+export const rejected = (t, tc) => {
+  t.notCalled(tc.cb.resolve)
+  t.calledOnce(tc.cb.reject)
 }
-export const notCalled = (t, cb) => {
-  t.notCalled(cb.resolve)
-  t.notCalled(cb.reject)
+export const notCalled = (t, tc) => {
+  t.notCalled(tc.cb.resolve)
+  t.notCalled(tc.cb.reject)
 }

--- a/test/common.ts
+++ b/test/common.ts
@@ -1,8 +1,8 @@
 import * as tape from 'tape'
 import * as sinon from 'sinon'
 
-export const test = (desc, f) => {
-  tape(desc, t => {
+const runTest = runner => (desc, f) => {
+  runner(desc, t => {
     // smush sinon.assert and tape API into a single object
     const s = sinon.assert
     s.pass = t.pass
@@ -10,6 +10,18 @@ export const test = (desc, f) => {
     f(Object.assign({}, t, s))
   })
 }
+
+export const test: any = runTest(tape)
+test.only = runTest(tape.only)
+
+export const observation = (node, signal) => ({node, signal, dna: 'testnet'})
+export const signal = (event, pending) => ({event, pending})
+export const pending = (group, event) => ({group, event})
+export const testCallback = (nodes) => ({
+  resolve: sinon.spy(),
+  reject: sinon.spy(),
+  nodes
+})
 
 
 export const resolved = (t, cb) => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,3 +1,4 @@
 
 require('./single-network')
 require('./multi-network')
+require('./timeouts')

--- a/test/multi-network.ts
+++ b/test/multi-network.ts
@@ -1,8 +1,6 @@
 import * as _ from 'lodash'
 
-import {Waiter} from '../src/waiter'
-import {FullSyncNetwork} from '../src/network'
-import {DnaId} from '../src/elements'
+import {DnaId, FullSyncNetwork, Waiter} from '../src/index'
 import {test} from './common'
 
 const nodes = {

--- a/test/timeouts.ts
+++ b/test/timeouts.ts
@@ -27,15 +27,86 @@ const withClock = f => {
 }
 
 
-test('soft timeout', withClock(async (t, clk) => {
-  const waiter = testWaiter({softTimeout: 2000, hardTimeout: 6000})
+test('soft timeout fires after one observation', withClock(async (t, clk) => {
+  const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
   waiter.handleObservation(observation('kristina', signal('x', [pending('Source', 'y')])))
   const cb0 = waiter.registerCallback(testCallback(null))!
   t.equal(waiter.callbacks.length, 1)
-  clk.tick(1000)
+  clk.tick(500)
   t.notCalled(cb0.onSoftTimeout)
-  clk.tick(1001)
-  t.called(cb0.onSoftTimeout)
-
+  clk.tick(500)
+  t.calledOnce(cb0.onSoftTimeout)
+  clk.tick(10000)
+  t.calledOnce(cb0.onSoftTimeout)
   t.end()
 }))
+
+test('hard timeout fires after one observation', withClock(async (t, clk) => {
+  const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
+  waiter.handleObservation(observation('kristina', signal('x', [pending('Source', 'y')])))
+  const cb0 = waiter.registerCallback(testCallback(null))!
+  t.equal(waiter.callbacks.length, 1)
+  clk.tick(500)
+  t.notCalled(cb0.onHardTimeout)
+  clk.tick(1000)
+  t.notCalled(cb0.onHardTimeout)
+  clk.tick(1000)
+  t.calledOnce(cb0.onHardTimeout)
+  t.calledOnce(cb0.onSoftTimeout)
+  t.end()
+}))
+
+
+test('timeouts reset with new relevant observations', withClock(async (t, clk) => {
+  const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
+  waiter.handleObservation(observation('kristina', signal('x', [pending('Validators', 'y')])))
+  const cb0 = waiter.registerCallback(testCallback(null))!
+
+  clk.tick(1000)
+  // first soft timeout triggered
+  t.callCount(cb0.onSoftTimeout, 1)
+
+  // a new observation comes in, resetting all timers
+  waiter.handleObservation(observation('kristina', signal('y', [])))
+
+  clk.tick(500)
+  t.callCount(cb0.onSoftTimeout, 1)
+
+  clk.tick(500)
+  // if that second observation hadn't happened, this would be when the hard timeout would occur
+  t.notCalled(cb0.onHardTimeout)
+  // instead, another soft timeout occurs
+  t.callCount(cb0.onSoftTimeout, 2)
+
+  // finally, the hard timeout interval has elasped since the last observation
+  clk.tick(1000)
+  t.callCount(cb0.onHardTimeout, 1)
+  t.end()
+}))
+
+// test('timeouts do not reset due to irrelevant observations', withClock(async (t, clk) => {
+//   const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
+//   waiter.handleObservation(observation('kristina', signal('x', [pending('Source', 'y')])))
+//   const cb0 = waiter.registerCallback(testCallback(null))!
+
+//   clk.tick(1000)
+//   // first soft timeout triggered
+//   t.calledOnce(cb0.onSoftTimeout)
+
+//   // a new observation comes in, resetting all timers
+//   waiter.handleObservation(observation('gina', signal('x', [pending('Source', 'y')])))
+
+//   clk.tick(1000)
+//   t.calledOnce(cb0.onHardTimeout)
+
+//   clk.tick(500)
+//   // if that second observation hadn't happened, this would be when the hard timeout would occur
+//   t.notCalled(cb0.onHardTimeout)
+//   // instead, another soft timeout occurs
+//   t.callCount(cb0.onSoftTimeout, 2)
+
+//   // finally, the hard timeout interval has elasped since the last observation
+//   clk.tick(1000)
+//   t.callCount(cb0.onHardTimeout, 1)
+//   t.end()
+// }))

--- a/test/timeouts.ts
+++ b/test/timeouts.ts
@@ -1,0 +1,41 @@
+import * as sinon from 'sinon'
+
+import {test, observation, signal, pending, testCallback} from './common'
+import {FullSyncNetwork, Waiter} from '../src/index'
+import {TimedCallback} from '../src/callback'
+
+const agents = ['kristina', 'gina']
+const testWaiter = (opts) => {
+  const network = new FullSyncNetwork(agents)
+  const waiter = new Waiter({testnet: network}, opts)
+  return waiter
+}
+
+const timerSandbox = sinon.createSandbox()
+const withClock = f => {
+  return t => {
+    timerSandbox.stub(TimedCallback.prototype, 'onSoftTimeout')
+    timerSandbox.stub(TimedCallback.prototype, 'onHardTimeout')
+    const clock = sinon.useFakeTimers()
+    try {
+      f(t, clock)
+    } finally {
+      clock.restore()
+      timerSandbox.restore()
+    }
+  }
+}
+
+
+test('soft timeout', withClock(async (t, clk) => {
+  const waiter = testWaiter({softTimeout: 2000, hardTimeout: 6000})
+  waiter.handleObservation(observation('kristina', signal('x', [pending('Source', 'y')])))
+  const cb0 = waiter.registerCallback(testCallback(null))!
+  t.equal(waiter.callbacks.length, 1)
+  clk.tick(1000)
+  t.notCalled(cb0.onSoftTimeout)
+  clk.tick(1001)
+  t.called(cb0.onSoftTimeout)
+
+  t.end()
+}))

--- a/test/timeouts.ts
+++ b/test/timeouts.ts
@@ -4,7 +4,7 @@ import {test, observation, signal, pending, testCallback} from './common'
 import {FullSyncNetwork, Waiter} from '../src/index'
 import {TimedCallback} from '../src/callback'
 
-const agents = ['kristina', 'gina']
+const agents = ['kristina', 'gina', 'alex']
 const testWaiter = (opts) => {
   const network = new FullSyncNetwork(agents)
   const waiter = new Waiter({testnet: network}, opts)
@@ -14,14 +14,15 @@ const testWaiter = (opts) => {
 const timerSandbox = sinon.createSandbox()
 const withClock = f => {
   return t => {
-    timerSandbox.stub(TimedCallback.prototype, 'onSoftTimeout')
-    timerSandbox.stub(TimedCallback.prototype, 'onHardTimeout')
+    // timerSandbox.stub(TimedCallback.prototype, 'onSoftTimeout')
+    // timerSandbox.stub(TimedCallback.prototype, 'onHardTimeout')
     const clock = sinon.useFakeTimers()
     try {
       f(t, clock)
     } finally {
+      clock.runAll()
       clock.restore()
-      timerSandbox.restore()
+      // timerSandbox.restore()
     }
   }
 }
@@ -30,7 +31,7 @@ const withClock = f => {
 test('soft timeout fires after one observation', withClock(async (t, clk) => {
   const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
   waiter.handleObservation(observation('kristina', signal('x', [pending('Source', 'y')])))
-  const cb0 = waiter.registerCallback(testCallback(null))!
+  const cb0 = testCallback(waiter, null)!
   t.equal(waiter.callbacks.length, 1)
   clk.tick(500)
   t.notCalled(cb0.onSoftTimeout)
@@ -44,7 +45,7 @@ test('soft timeout fires after one observation', withClock(async (t, clk) => {
 test('hard timeout fires after one observation', withClock(async (t, clk) => {
   const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
   waiter.handleObservation(observation('kristina', signal('x', [pending('Source', 'y')])))
-  const cb0 = waiter.registerCallback(testCallback(null))!
+  const cb0 = testCallback(waiter, null)!
   t.equal(waiter.callbacks.length, 1)
   clk.tick(500)
   t.notCalled(cb0.onHardTimeout)
@@ -60,14 +61,14 @@ test('hard timeout fires after one observation', withClock(async (t, clk) => {
 test('timeouts reset with new relevant observations', withClock(async (t, clk) => {
   const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
   waiter.handleObservation(observation('kristina', signal('x', [pending('Validators', 'y')])))
-  const cb0 = waiter.registerCallback(testCallback(null))!
+  const cb0 = testCallback(waiter, null)!
 
   clk.tick(1000)
   // first soft timeout triggered
   t.callCount(cb0.onSoftTimeout, 1)
 
   // a new observation comes in, resetting all timers
-  waiter.handleObservation(observation('kristina', signal('y', [])))
+  waiter.handleObservation(observation('gina', signal('y', [])))
 
   clk.tick(500)
   t.callCount(cb0.onSoftTimeout, 1)
@@ -84,29 +85,59 @@ test('timeouts reset with new relevant observations', withClock(async (t, clk) =
   t.end()
 }))
 
-// test('timeouts do not reset due to irrelevant observations', withClock(async (t, clk) => {
-//   const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
-//   waiter.handleObservation(observation('kristina', signal('x', [pending('Source', 'y')])))
-//   const cb0 = waiter.registerCallback(testCallback(null))!
+test('timeouts do not reset due to irrelevant observations', withClock(async (t, clk) => {
+  const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
+  waiter.handleObservation(observation('kristina', signal('x', [pending('Source', 'y')])))
+  const cb0 = testCallback(waiter, null)!
 
-//   clk.tick(1000)
-//   // first soft timeout triggered
-//   t.calledOnce(cb0.onSoftTimeout)
+  clk.tick(1000)
+  // first soft timeout triggered
+  t.calledOnce(cb0.onSoftTimeout)
 
-//   // a new observation comes in, resetting all timers
-//   waiter.handleObservation(observation('gina', signal('x', [pending('Source', 'y')])))
+  // a new observation comes in, resetting all timers
+  waiter.handleObservation(observation('gina', signal('x', [pending('Source', 'y')])))
 
-//   clk.tick(1000)
-//   t.calledOnce(cb0.onHardTimeout)
+  clk.tick(1000)
+  t.calledOnce(cb0.onHardTimeout)
 
-//   clk.tick(500)
-//   // if that second observation hadn't happened, this would be when the hard timeout would occur
-//   t.notCalled(cb0.onHardTimeout)
-//   // instead, another soft timeout occurs
-//   t.callCount(cb0.onSoftTimeout, 2)
+  t.end()
+}))
 
-//   // finally, the hard timeout interval has elasped since the last observation
-//   clk.tick(1000)
-//   t.callCount(cb0.onHardTimeout, 1)
-//   t.end()
-// }))
+
+
+test('timeout reset scenario 1', withClock(async (t, clk) => {
+  const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
+  waiter.handleObservation(observation('kristina', signal('x', [pending('Validators', 'y')])))
+  const cb0 = testCallback(waiter, ['kristina', 'gina'])
+  const cb1 = testCallback(waiter, ['gina', 'alex'])
+  t.callCount(cb0.onSoftTimeout, 0)
+  t.callCount(cb0.onHardTimeout, 0)
+  t.callCount(cb1.onSoftTimeout, 0)
+  t.callCount(cb1.onHardTimeout, 0)
+
+  clk.tick(1000)
+  // first soft timeout triggered
+  t.callCount(cb0.onSoftTimeout, 1)
+  t.callCount(cb0.onHardTimeout, 0)
+  t.callCount(cb1.onSoftTimeout, 1)
+  t.callCount(cb1.onHardTimeout, 0)
+
+  // cb0 does not reset, but cb1 does
+  waiter.handleObservation(observation('gina', signal('w', [pending('Validators', 'z')])))
+  waiter.handleObservation(observation('alex', signal('z', [])))
+
+  clk.tick(1000)
+  t.callCount(cb0.onSoftTimeout, 1)
+  t.callCount(cb0.onHardTimeout, 1)
+  t.callCount(cb1.onSoftTimeout, 2)
+  t.callCount(cb1.onHardTimeout, 0)
+
+
+  clk.tick(1000)
+  t.callCount(cb0.onSoftTimeout, 1)
+  t.callCount(cb0.onHardTimeout, 1)
+  t.callCount(cb1.onSoftTimeout, 2)
+  t.callCount(cb1.onHardTimeout, 1)
+
+  t.end()
+}))

--- a/test/timeouts.ts
+++ b/test/timeouts.ts
@@ -1,103 +1,91 @@
 import * as sinon from 'sinon'
 
-import {test, observation, signal, pending, testCallback} from './common'
-import {FullSyncNetwork, Waiter} from '../src/index'
+import {
+  test,
+  observation,
+  signal,
+  pending,
+  testCallback,
+  withClock,
+  testWaiter as makeTestWaiter,
+  TIMEOUTS
+} from './common'
 import {TimedCallback} from '../src/callback'
 
 const agents = ['kristina', 'gina', 'alex']
-const testWaiter = (opts) => {
-  const network = new FullSyncNetwork(agents)
-  const waiter = new Waiter({testnet: network}, opts)
-  return waiter
-}
+const testWaiter = (opts?) => makeTestWaiter(agents, opts)
 
-const timerSandbox = sinon.createSandbox()
-const withClock = f => {
-  return t => {
-    // timerSandbox.stub(TimedCallback.prototype, 'onSoftTimeout')
-    // timerSandbox.stub(TimedCallback.prototype, 'onHardTimeout')
-    const clock = sinon.useFakeTimers()
-    try {
-      f(t, clock)
-    } finally {
-      clock.runAll()
-      clock.restore()
-      // timerSandbox.restore()
-    }
-  }
-}
-
+const {soft, hard} = TIMEOUTS
 
 test('soft timeout fires after one observation', withClock(async (t, clk) => {
-  const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
+  const waiter = testWaiter()
   waiter.handleObservation(observation('kristina', signal('x', [pending('Source', 'y')])))
   const cb0 = testCallback(waiter, null)!
   t.equal(waiter.callbacks.length, 1)
-  clk.tick(500)
+  clk.tick(soft / 2)
   t.notCalled(cb0.onSoftTimeout)
-  clk.tick(500)
+  clk.tick(soft / 2)
   t.calledOnce(cb0.onSoftTimeout)
-  clk.tick(10000)
+  clk.tick(hard)
   t.calledOnce(cb0.onSoftTimeout)
   t.end()
 }))
 
 test('hard timeout fires after one observation', withClock(async (t, clk) => {
-  const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
+  const waiter = testWaiter()
   waiter.handleObservation(observation('kristina', signal('x', [pending('Source', 'y')])))
   const cb0 = testCallback(waiter, null)!
   t.equal(waiter.callbacks.length, 1)
-  clk.tick(500)
+  clk.tick(soft / 2)
   t.notCalled(cb0.onHardTimeout)
-  clk.tick(1000)
+  clk.tick(hard / 2)
   t.notCalled(cb0.onHardTimeout)
-  clk.tick(1000)
+  clk.tick(hard / 2)
   t.calledOnce(cb0.onHardTimeout)
   t.calledOnce(cb0.onSoftTimeout)
   t.end()
 }))
 
-
 test('timeouts reset with new relevant observations', withClock(async (t, clk) => {
-  const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
+  const waiter = testWaiter()
   waiter.handleObservation(observation('kristina', signal('x', [pending('Validators', 'y')])))
   const cb0 = testCallback(waiter, null)!
 
-  clk.tick(1000)
+  clk.tick(soft)
   // first soft timeout triggered
   t.callCount(cb0.onSoftTimeout, 1)
 
   // a new observation comes in, resetting all timers
   waiter.handleObservation(observation('gina', signal('y', [])))
 
-  clk.tick(500)
+  clk.tick(soft / 2)
   t.callCount(cb0.onSoftTimeout, 1)
 
-  clk.tick(500)
+  clk.tick(soft / 2)
   // if that second observation hadn't happened, this would be when the hard timeout would occur
   t.notCalled(cb0.onHardTimeout)
   // instead, another soft timeout occurs
   t.callCount(cb0.onSoftTimeout, 2)
 
   // finally, the hard timeout interval has elasped since the last observation
-  clk.tick(1000)
+  clk.tick(hard)
   t.callCount(cb0.onHardTimeout, 1)
   t.end()
 }))
 
 test('timeouts do not reset due to irrelevant observations', withClock(async (t, clk) => {
-  const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
+  const waiter = testWaiter()
   waiter.handleObservation(observation('kristina', signal('x', [pending('Source', 'y')])))
   const cb0 = testCallback(waiter, null)!
 
-  clk.tick(1000)
+  clk.tick(soft)
   // first soft timeout triggered
   t.calledOnce(cb0.onSoftTimeout)
 
   // a new observation comes in, resetting all timers
   waiter.handleObservation(observation('gina', signal('x', [pending('Source', 'y')])))
 
-  clk.tick(1000)
+  clk.tick(hard)
   t.calledOnce(cb0.onHardTimeout)
 
   t.end()
@@ -106,7 +94,7 @@ test('timeouts do not reset due to irrelevant observations', withClock(async (t,
 
 
 test('timeout reset scenario 1', withClock(async (t, clk) => {
-  const waiter = testWaiter({softTimeout: 1000, hardTimeout: 2000})
+  const waiter = testWaiter()
   waiter.handleObservation(observation('kristina', signal('x', [pending('Validators', 'y')])))
   const cb0 = testCallback(waiter, ['kristina', 'gina'])
   const cb1 = testCallback(waiter, ['gina', 'alex'])
@@ -115,7 +103,7 @@ test('timeout reset scenario 1', withClock(async (t, clk) => {
   t.callCount(cb1.onSoftTimeout, 0)
   t.callCount(cb1.onHardTimeout, 0)
 
-  clk.tick(1000)
+  clk.tick(soft)
   // first soft timeout triggered
   t.callCount(cb0.onSoftTimeout, 1)
   t.callCount(cb0.onHardTimeout, 0)
@@ -126,14 +114,14 @@ test('timeout reset scenario 1', withClock(async (t, clk) => {
   waiter.handleObservation(observation('gina', signal('w', [pending('Validators', 'z')])))
   waiter.handleObservation(observation('alex', signal('z', [])))
 
-  clk.tick(1000)
+  clk.tick(hard - soft)
   t.callCount(cb0.onSoftTimeout, 1)
   t.callCount(cb0.onHardTimeout, 1)
   t.callCount(cb1.onSoftTimeout, 2)
   t.callCount(cb1.onHardTimeout, 0)
 
 
-  clk.tick(1000)
+  clk.tick(soft)
   t.callCount(cb0.onSoftTimeout, 1)
   t.callCount(cb0.onHardTimeout, 1)
   t.callCount(cb1.onSoftTimeout, 2)


### PR DESCRIPTION
Makes it so when new observations come in, if they serve to reduce the number of pending events, the soft and hard timeout timers will reset. This makes it so that as long as a test is making steady progress towards consistency, it will not do a hard timeout. Basically, debounce for timeouts.